### PR TITLE
Deprecated JSONBuilder, replace with json_encode for php 5.2+

### DIFF
--- a/kernel/framework/builder/JSONBuilder.class.php
+++ b/kernel/framework/builder/JSONBuilder.class.php
@@ -31,65 +31,15 @@
  */
 class JSONBuilder
 {
-	public static function build(array $object)
-	{
-		return self::build_array($object);
-	}
-
-	private static function build_array(array $array, $subarray = false)
-	{
-		$values = array();
-		$is_map = self::is_map($array);
-		foreach ($array as $key => $value)
-		{
-			if ($is_map)
-			{
-				$values[] = '"' . $key . '":' . self::build_element($value);
-			}
-			else
-			{
-				$values[] = self::build_element($value);
-			}
-		}
-		return ($subarray ? '[' : '{') . implode(',', $values) . ($subarray ? ']' : '}');
-	}
-
-	private static function build_element($object)
-	{
-		if (is_array($object))
-		{
-			return self::build_array($object, true);
-		}
-		return self::build_raw_value($object);
-	}
-
-	private static function build_raw_value($value)
-	{
-		if (is_bool($value))
-		{
-			return $value ? 'true' : 'false';
-		}
-		elseif (is_int($value))
-		{
-			return strval($value);
-		}
-		elseif (is_float($value))
-		{
-			return strval($value);
-		}
-		return TextHelper::to_json_string($value);
-	}
-
-	private static function is_map(array $array)
-	{
-		foreach (array_keys($array) as $key)
-		{
-			if (is_string($key))
-			{
-				return true;
-			}
-		}
-		return false;
-	}
+    /**
+     * @deprecated Use json_encode instead
+     * @param array $object
+     * @return string
+     */
+    public static function build(array $object)
+    {
+        return json_encode($object);
+    }
 }
+
 ?>

--- a/kernel/framework/mvc/response/JSONResponse.class.php
+++ b/kernel/framework/mvc/response/JSONResponse.class.php
@@ -26,7 +26,6 @@
  ###################################################*/
 
 
-
 /**
  * @author loic rouchon <loic.rouchon@phpboost.com>
  * @desc the response
@@ -34,22 +33,23 @@
  */
 class JSONResponse implements Response
 {
-	private $json;
+    private $json;
 
-	public function __construct(array $json_object)
-	{
-		$session = AppContext::get_session();
-		$session->no_session_location();
-		$session->update_location('');
-		
-		$this->json = JSONBuilder::build($json_object);
-	}
+    public function __construct(array $json_object)
+    {
+        $session = AppContext::get_session();
+        $session->no_session_location();
+        $session->update_location('');
 
-	public function send()
-	{
-		$response = AppContext::get_response();
-		$response->set_header('Content-type', 'application/json; charset=windows-1252');
-		echo $this->json;
-	}
+        $this->json = json_encode($json_object);
+    }
+
+    public function send()
+    {
+        $response = AppContext::get_response();
+        $response->set_header('Content-type', 'application/json; charset=windows-1252');
+        echo $this->json;
+    }
 }
+
 ?>


### PR DESCRIPTION
json_encode exist for php version 5.2 and newer. The JSONBuilder class has no reason to be maintained