### PR TITLE
[CRITICAL][FIX] reverse "Disallow scripts execution"

### DIFF
--- a/kernel/framework/phpboost/cache/HtaccessFileCache.class.php
+++ b/kernel/framework/phpboost/cache/HtaccessFileCache.class.php
@@ -44,7 +44,7 @@ class HtaccessFileCache implements CacheData
 		$this->htaccess_file_content = '';
 		$this->general_config = GeneralConfig::load();
 		
-		$this->disallow_scripts_execution();
+		//$this->disallow_scripts_execution();
 		
 		$this->add_free_php56();
 		


### PR DESCRIPTION
reverse because OVH like "many" other hosting provider use PHP as CGI, so with this, PHP is disabled

Example : [Fri Dec 02 23:11:50 2016] [error] [client XXX.XXX.XXX.XXX] [host example.ovh] Options ExecCGI is off in this directory: /homez.387/website/www/index.php