### PR TITLE
[FIX] #1732 [phpmailer] Class 'SMTP' not found

### DIFF
--- a/kernel/framework/io/mail/AbstractPHPMailerMailService.class.php
+++ b/kernel/framework/io/mail/AbstractPHPMailerMailService.class.php
@@ -25,6 +25,7 @@
  *
  ###################################################*/
 
+include_once PATH_TO_ROOT.'/kernel/lib/php/phpmailer/PHPMailerAutoload.php';
 include_once PATH_TO_ROOT . '/kernel/lib/php/phpmailer/class.phpmailer.php';
 
 abstract class AbstractPHPMailerMailService implements MailService

--- a/kernel/framework/io/mail/SMTPMailService.class.php
+++ b/kernel/framework/io/mail/SMTPMailService.class.php
@@ -40,7 +40,7 @@ class SMTPMailService extends AbstractPHPMailerMailService
 	protected function set_send_settings(PHPMailer $mailer)
 	{
 		$mailer->IsSMTP();
-		$mailer->SMTPDebug = 1;
+		$mailer->SMTPDebug = 0;
 		$mailer->SMTPAuth = true;
 		$mailer->Timeout = 1;
 		$auth_mode = $this->configuration->get_auth_mode();


### PR DESCRIPTION
[FIX] #1732 [phpmailer] Class 'SMTP' not found
C'est moche j'avais pas vu lors du commit des CVE et normalement cela règle le problème (pas encore testé et j’attends les détails demandé sur le rapport de bug)