### PR TITLE
[FIX] ticket 1995

### DIFF
--- a/kernel/framework/io/db/DBQuerier.class.php
+++ b/kernel/framework/io/db/DBQuerier.class.php
@@ -81,8 +81,8 @@ class DBQuerier implements SQLQuerier
 	public function insert($table_name, array $columns)
 	{
 		$columns_names = array_keys($columns);
-		$query = 'INSERT INTO ' . $table_name . ' (' . implode(', ', $columns_names) .
-		  ') VALUES (:' . implode(', :', $columns_names) . ');';
+		$query = 'INSERT INTO ' . $table_name . ' (`' . implode('`, `', $columns_names) .
+		  '`) VALUES (:' . implode(', :', $columns_names) . ');';
 		return $this->querier->inject($query, $columns);
 	}
 


### PR DESCRIPTION
Erreur MySQL sur installation à l'étape de déclaration des comptes admin

Il semblerait que le serveur MySQL n'accepte pas certains noms de champ (comme groups). Il est donc nécessaire de les échapper dans le script SQL.