### PR TITLE
Update MediaFeedProvider.class.php

### DIFF
--- a/media/phpboost/MediaFeedProvider.class.php
+++ b/media/phpboost/MediaFeedProvider.class.php
@@ -65,7 +65,10 @@ class MediaFeedProvider implements FeedProvider
 				$item->set_auth(CategoriesService::get_categories_manager('media')->get_heritated_authorizations($row['id_category'], Category::READ_AUTHORIZATIONS, Authorizations::AUTH_PARENT_PRIORITY));
 
 				$enclosure = new FeedItemEnclosure();
-				$enclosure->set_lenght(@filesize($row['file_url']));
+				if (strpos($row['file_url'], 'http://') === 0 || strpos($row['file_url'], 'https://') === 0) {
+					$enclosure->set_lenght(0); } 
+				else {
+        				$enclosure->set_lenght(@filesize($row['file_url'])); }
 				$enclosure->set_type($row['mime_type']);
 				$enclosure->set_url($row['file_url']);
 				$item->set_enclosure($enclosure);


### PR DESCRIPTION
fix error
```
 Warning : filesize(): stat failed for "https://www.mydomain.tld/"

[0] /media/phpboost/MediaFeedProvider.class.php:68
[0] /media/phpboost/MediaFeedProvider.class.php:68 - filesize()
[1] /kernel/framework/content/feed/Feed.class.php:268 - MediaFeedProvider->get_feed_data_struct()
[2] /kernel/framework/phpboost/menu/feed/FeedMenu.class.php:132 - Feed::get_parsed()
[3] /kernel/framework/phpboost/environment/SiteDisplayGraphicalEnvironment.class.php:216 - FeedMenu->display()
[4] /kernel/framework/phpboost/environment/SiteDisplayGraphicalEnvironment.class.php:70 - SiteDisplayGraphicalEnvironment->display_menus()
[5] /kernel/framework/mvc/response/AbstractResponse.class.php:49 - SiteDisplayGraphicalEnvironment->display()
[6] /kernel/framework/mvc/dispatcher/UrlControllerMapper.class.php:73 - AbstractResponse->send()
[7] /kernel/framework/mvc/dispatcher/UrlControllerMapper.class.php:44 - UrlControllerMapper->do_call()
[8] /kernel/framework/mvc/dispatcher/Dispatcher.class.php:47 - UrlControllerMapper->call()
[9] /kernel/framework/mvc/dispatcher/DispatchManager.class.php:26 - Dispatcher->dispatch()
[10] /HomeLanding/index.php:25 - DispatchManager::dispatch()
```