### PR TITLE
FIX Add Module SQL Categories Error

### DIFF
--- a/admin/member/controllers/AdminMemberConfigController.class.php
+++ b/admin/member/controllers/AdminMemberConfigController.class.php
@@ -98,7 +98,7 @@ class AdminMemberConfigController extends DefaultAdminController
 		$fieldset->add_field(new FormFieldCheckbox('user_activation_admin_email', $this->lang['user.activation.admin.email'], $this->user_accounts_config->get_administrator_accounts_validation_email(),
 			array(
 				'class' => 'custom-checkbox top-field',
-				'hidden' => !$this->user_accounts_config->is_registration_enabled() || !$this->user_accounts_config->get_member_accounts_validation_method() == UserAccountsConfig::ADMINISTRATOR_USER_ACCOUNTS_VALIDATION
+				'hidden' => !$this->user_accounts_config->is_registration_enabled() || $this->user_accounts_config->get_member_accounts_validation_method() != UserAccountsConfig::ADMINISTRATOR_USER_ACCOUNTS_VALIDATION
 			)
 		));
 

--- a/admin/member/controllers/AdminMemberConfigController.class.php
+++ b/admin/member/controllers/AdminMemberConfigController.class.php
@@ -98,7 +98,7 @@ class AdminMemberConfigController extends DefaultAdminController
 		$fieldset->add_field(new FormFieldCheckbox('user_activation_admin_email', $this->lang['user.activation.admin.email'], $this->user_accounts_config->get_administrator_accounts_validation_email(),
 			array(
 				'class' => 'custom-checkbox top-field',
-				'hidden' => !$this->user_accounts_config->is_registration_enabled() || $this->user_accounts_config->get_member_accounts_validation_method() != UserAccountsConfig::ADMINISTRATOR_USER_ACCOUNTS_VALIDATION
+				'hidden' => !$this->user_accounts_config->is_registration_enabled() || !$this->user_accounts_config->get_member_accounts_validation_method() == UserAccountsConfig::ADMINISTRATOR_USER_ACCOUNTS_VALIDATION
 			)
 		));
 

--- a/admin/modules/controllers/AdminModuleAddController.class.php
+++ b/admin/modules/controllers/AdminModuleAddController.class.php
@@ -25,6 +25,7 @@ class AdminModuleAddController extends DefaultAdminController
 		$message_success = $message_warning = '';
 		$modules_selected = $modules_success = 0;
 		$module_number = 1;
+		ClassLoader::generate_classlist(true);
 		foreach ($this->get_modules_not_installed() as $name => $module)
 		{
 			if ($request->get_string('add-' . $module->get_id(), false) || ($request->get_string('add-selected-modules', false) && $request->get_value('add-checkbox-' . $module_number, 'off') == 'on'))


### PR DESCRIPTION
Après installation, l’ajout d’un premier module supplémentaire génère une erreur non bloquante (le module est quand même installé)